### PR TITLE
make sure bank component is registered outside of debug mode

### DIFF
--- a/savethewench/component/__init__.py
+++ b/savethewench/component/__init__.py
@@ -1,6 +1,7 @@
 from .game import InitGame
 #-- ensure components are registered
 from .actions import *
+from .bank import *
 from .casino import *
 from .coffee_shop import *
 from .crypto import *


### PR DESCRIPTION
When running the game outside of debug mode, an error occurs after the tutorial:

RuntimeError: No component registered under "Bank"

This makes sure the component is registered in any mode.