### PR TITLE
Add bounty hunter perk variants

### DIFF
--- a/bookoftench/data/perks.py
+++ b/bookoftench/data/perks.py
@@ -33,6 +33,8 @@ SOLOMON_TRAIN = "Solomon Train"
 TENCH_EYES = "Tench Eyes"
 TENCH_GENES = "Tench Genes"
 TENCH_THE_BOUNTY_HUNTER = "Tench the Bounty Hunter"
+CRENCH_THE_BOUNTY_HUNTER = "Crench the Bounty Hunter"
+DENCH_THE_BOUNTY_HUNTER = "Dench the Bounty Hunter"
 TRADE_SHIP = "Trade Ship"
 USED_SNEAKERS = "Used Sneakers"
 VAGABONDAGE = "Vagabondage"
@@ -281,6 +283,18 @@ Perks = [
         'description': "Earn +25 coins from each bounty enemy",
         'wrapper_type': WrapperType.INT_CHANGE,
         'wrapper_config': {'change': 25}
+    },
+    {
+        'name': CRENCH_THE_BOUNTY_HUNTER,
+        'cost': 180,
+        'description': "Earn 15% more from each bounty enemy",
+        'wrapper_type': WrapperType.INT_CHANGE_BY_PERCENT,
+        'wrapper_config': {'change': 15}
+    },
+    {
+        'name': DENCH_THE_BOUNTY_HUNTER,
+        'cost': 170,
+        'description': "15% chance to encounter the bounty target in matching areas",
     },
     {
         'name': TRADE_SHIP,

--- a/bookoftench/model/area.py
+++ b/bookoftench/model/area.py
@@ -22,7 +22,7 @@ from .trait import load_traits
 from .weapon import load_weapon, make_elite_weapon
 from bookoftench.data.enviroment import NIGHTTIME, FULL
 from bookoftench.data.illnesses import Illnesses, LATE_ONSET_SIDS
-from bookoftench.data.perks import SHERLOCK_TENCH
+from bookoftench.data.perks import DENCH_THE_BOUNTY_HUNTER, SHERLOCK_TENCH
 from bookoftench.data.weapons import CLAWS, BLIND, SPECIAL
 from ..audio import play_sound
 from ..data.audio import ENEMY_APPEARS, OWL_SFX, WEREWOLF_SFX
@@ -104,7 +104,14 @@ class Area:
             if random.random() < min(0.15, 0.01 * len(self.enemies_seen)):  # If random < scaling float value
                 enemy_name = random.choice(tuple(self.enemies_seen))  # Select enemy from seen
 
-        if perk_is_active(SHERLOCK_TENCH):  # 10% chance of wanted enemy encounter if perk is active
+        # Dench keeps bounty hunting scalable as new enemies are added: when the
+        # current area can naturally spawn the bounty target, there is a flat
+        # chance that the next enemy is the target regardless of pool size.
+        if perk_is_active(DENCH_THE_BOUNTY_HUNTER):
+            if self.name in wanted.areas and random.random() < 0.15:
+                enemy_name = wanted.name
+
+        if perk_is_active(SHERLOCK_TENCH):  # 15% chance of wanted enemy encounter if perk is active
             if self.name in wanted.areas and random.random() < 0.15:
                 enemy_name = wanted.name
 

--- a/bookoftench/model/game_state.py
+++ b/bookoftench/model/game_state.py
@@ -6,7 +6,7 @@ from typing import List, Dict
 import bookoftench.service.crypto_service as crypto_service
 from bookoftench import event_logger
 from bookoftench.audio import play_music, play_sound
-from bookoftench.data.perks import TENCH_THE_BOUNTY_HUNTER, NEPTUNE
+from bookoftench.data.perks import TENCH_THE_BOUNTY_HUNTER, CRENCH_THE_BOUNTY_HUNTER, NEPTUNE
 from bookoftench.event_base import EventType, Event
 from bookoftench.event_logger import subscribe_function
 from bookoftench.settings import Settings, set_settings
@@ -105,6 +105,7 @@ class GameState:
         return self.current_area.shop
 
     @property
+    @attach_perk(CRENCH_THE_BOUNTY_HUNTER, silent=True)
     @attach_perk(TENCH_THE_BOUNTY_HUNTER, silent=True)
     def bounty(self) -> int:
         return self._bounty


### PR DESCRIPTION
Closes #247

/claim

Adds the requested split bounty hunter perks.

Changes:
- Adds `Crench the Bounty Hunter` as a 15% bounty payout boost
- Adds `Dench the Bounty Hunter` as a 15% chance to force the bounty target when searching an area where the target can spawn
- Keeps the existing `Tench the Bounty Hunter` flat +25 bounty behavior intact
- Applies Crench through the existing perk wrapper system on `GameState.bounty`
- Applies Dench in `Area.spawn_enemy` before enemy finalization so it scales independently of enemy pool size

Validation:
- `python3 -m py_compile bookoftench/data/perks.py bookoftench/model/game_state.py`
- `git diff --check`

Notes:
- `bookoftench/model/area.py` already contains Python syntax errors in unchanged f-string lines, so direct py_compile of that file is blocked by existing code unrelated to this change.